### PR TITLE
fix: RuntimeError during component unload and sensor update

### DIFF
--- a/custom_components/bs20/__init__.py
+++ b/custom_components/bs20/__init__.py
@@ -49,15 +49,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a device entry."""
     # Remove the entry from the global dictionary
+    # Get the hub instance and call close on it
     if entry.entry_id in global_udp_entries:
+        hub_instance = global_udp_entries[entry.entry_id].runtime_data
+        await hub_instance.close()
         del global_udp_entries[entry.entry_id]
+
+    # Unload platforms before stopping the server
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     # Stop the UDP server if no devices are left
     if not global_udp_entries:
         await stop_udp_server()
-
-    # Unload platforms
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     return unload_ok
 

--- a/custom_components/bs20/hub.py
+++ b/custom_components/bs20/hub.py
@@ -39,6 +39,7 @@ class Hub:
         self._current_userId = None
         self._current_current = None
         self._unlocked = False
+        self._unloaded = False
 
     async def init_numbers(self, hass, async_add_entities: AddEntitiesCallback):
         new_devices = []
@@ -309,7 +310,16 @@ class Hub:
         await asyncio.sleep(60)  # Wait for 60 seconds
         self.online = False
 
+    async def close(self):
+        """Signal that the hub is being unloaded."""
+        self._unloaded = True
+        if self._online_timer:
+            self._online_timer.cancel()
+        self._devices = {}
+
     async def decode_data(self, data: bytes, addr: tuple) -> None:
+        if self._unloaded:
+            return
         self._port = addr[1]
         
         calculatedLen = data[2] << 8 + data[3] & 0xff

--- a/custom_components/bs20/sensor.py
+++ b/custom_components/bs20/sensor.py
@@ -350,8 +350,9 @@ class OtherSensor(SensorEntity):
     
     @callback
     def async_update_callback(self, reason):
-        self.async_schedule_update_ha_state()
-    
+        if self.hass is not None:
+            self.async_schedule_update_ha_state()
+
     @property
     def available(self) -> bool:
         return self._hub.available


### PR DESCRIPTION
This PR resolves a RuntimeError that occurs when the component continues to process UDP datagrams while being unloaded.

Changes:
- **Hub Shutdown**: Implemented a `close()` method in the `Hub` class to flag the hub as unloaded and stop processing new data.
- **Unload Logic**: Updated `__init__.py` to call `hub.close()` before unloading platforms, ensuring a clean shutdown.
- **Sensor Safety**: Added a check in `sensor.py` to ensure `self.hass` is not None before scheduling state updates, preventing updates to detached entities.